### PR TITLE
Fix: Overlapping text in tasks list

### DIFF
--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -32,7 +32,6 @@ export function spawnTask(
   state: AppState,
   onUpdate: () => void,
 ): void {
-  console.log(task.command);
   const subProcess = childProcess.spawn('sh', ['-c', task.command], {
     cwd: task.cwd,
     env: {


### PR DESCRIPTION
Fixed #2. Stray console log was writing over the tasks list.