### PR TITLE
fix: give npm colour

### DIFF
--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -35,7 +35,8 @@ export function spawnTask(
     cwd: task.cwd,
     env: {
       ...process.env,
-      FORCE_COLOR: '1',
+      npm_config_color: 'always',
+      FORCE_COLOR: '3',
       CLICOLOR_FORCE: '1',
     },
   });


### PR DESCRIPTION
For some reason npm requires a specific env var to be set to output colour. Fixes #8.